### PR TITLE
Add gh action to perform release tasks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,6 @@ jobs:
         git commit -m "Update version to ${{ steps.version.output }}"
 
     - name: Push changes
-      uses: ad-m/github-push-action@main
+      uses: ad-m/github-push-action@master
       with:
         github_token: ${{ env.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+
+on:
+  pull_request:
+    types: [opened]
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  update-version:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check if PR title starts with "Create release:"
+      if: startsWith(github.event.pull_request.title, 'Create release:')
+      run: echo "PR title starts with 'Create release:', proceeding with update"
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Get version from PR title
+      run: echo "$(echo "${{ github.event.pull_request.title }}" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')"
+      id: version
+
+    - name: Update package.json with new version
+      run: |
+        sed -i "s/\"version\".*/\"version\": \"${{ steps.version.output }}\"/" package.json
+        git diff
+
+    - name: Update README with new version
+      run: |
+        sed -i "s/\/onsdigital\/design-system-react#.*/\/onsdigital\/design-system-react#${{ steps.version.output }}/" README.md
+        git diff
+
+    - name: Run build command
+      run: yarn build-package
+
+    - name: Commit changes
+      run: |
+        git config --global user.email "action@github.com"
+        git config --global user.name "Github Action"
+        git add .
+        git commit -m "Update version to ${{ steps.version.output }}"
+
+    - name: Push changes
+      uses: ad-m/github-push-action@main
+      with:
+        github_token: ${{ env.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build:examples:refresh": "ts-node ./scripts/refresh-example-components",
     "build:styles": "ts-node ./scripts/build-styles",
     "build-static-preview": "export NODE_ENV=production; yarn clean && yarn build:examples && yarn build:styles && ts-node ./scripts/build-static-preview",
+    "build-package": "export NODE_ENV=production; rm -rf build && yarn build && mv dist build",
     "clean": "rm -rf dist",
     "start": "yarn build:styles && yarn build:examples && yarn start:dev-server",
     "start:dev-server": "ts-node ./lib/dev-server",


### PR DESCRIPTION
The GH action:

- Runs when a PR is created with a title that starts with "Create release:"
- The title will also have a version string:  "Create release: v1.1.1"
- Takes the version string from title and updates the version number in package.json
- Also updates the version number in the readme.md file. The string to update is 'https://github.com/ONSdigital/design-system-react#v1.0.0'
- runs a build command: yarn build-package (this creates a /build folder with examples and css)
- pushes a commit to the branch with all of the changes 