### PR TITLE
Add GPG import to build release pipeline

### DIFF
--- a/.github/workflows/build-release-pr.yml
+++ b/.github/workflows/build-release-pr.yml
@@ -13,7 +13,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-        
+      - name: Import GPG key
+        run: |
+          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --import --batch --yes
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+
+      - name: Configure Git to use GPG key
+        run: |
+          git config --global user.signingkey ${{ secrets.GPG_KEY_ID }}
+          git config --global commit.gpgSign true
+
       - name: Get version from package.json
         id: get-version
         run: echo "PACKAGE_VERSION=$(jq -r '.version' package.json)" >> $GITHUB_ENV


### PR DESCRIPTION
The pipeline failed due to the commit not being signed correctly. This adds a step to the workflow to import the gpg key.